### PR TITLE
update copyright headers for all Haskell modules not in Crypto

### DIFF
--- a/Examples/Example1.hs
+++ b/Examples/Example1.hs
@@ -1,5 +1,14 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
+
 module Main where
 
 import PC.Bytes.ByteArray

--- a/Examples/Example2.hs
+++ b/Examples/Example2.hs
@@ -1,5 +1,14 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
+
 module Main where
 
 import PC.Crypto.Prim.Curve25519

--- a/Examples/Example4.hs
+++ b/Examples/Example4.hs
@@ -1,7 +1,16 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DataKinds #-}
+
 module Main where
 
 import Data.ByteString.Base64 as BS

--- a/Examples/Examples.hs
+++ b/Examples/Examples.hs
@@ -1,3 +1,11 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
 -- ------------------------------------------------------ --
 -- Copyright © 2014 AlephCloud Systems, Inc.
 -- ------------------------------------------------------ --

--- a/Examples/Poly1305.hs
+++ b/Examples/Poly1305.hs
@@ -1,7 +1,16 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DataKinds #-}
+
 module Main where
 
 import Data.ByteString.Base16 as B16

--- a/PC/Crypto/Prim/Aes.hs
+++ b/PC/Crypto/Prim/Aes.hs
@@ -1,12 +1,13 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE CPP #-}
+
 module PC.Crypto.Prim.Aes
 #if defined(NATIVE)
 ( module PC.Crypto.Prim.Aes.Native ) where

--- a/PC/Crypto/Prim/Aes/Native.hs
+++ b/PC/Crypto/Prim/Aes/Native.hs
@@ -1,11 +1,11 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PackageImports #-}
@@ -13,6 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+
 module PC.Crypto.Prim.Aes.Native
 ( AesKey256
 , aesKey256Length

--- a/PC/Crypto/Prim/Bn.hs
+++ b/PC/Crypto/Prim/Bn.hs
@@ -1,12 +1,13 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE CPP #-}
+
 module PC.Crypto.Prim.Bn
 #if defined(NATIVE)
 ( module PC.Crypto.Prim.Bn.Native ) where import PC.Crypto.Prim.Bn.Native

--- a/PC/Crypto/Prim/Bn/Native.hs
+++ b/PC/Crypto/Prim/Bn/Native.hs
@@ -1,16 +1,17 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module PC.Crypto.Prim.Bn.Native
 (
 -- * Big Numbers

--- a/PC/Crypto/Prim/ChaCha.hs
+++ b/PC/Crypto/Prim/ChaCha.hs
@@ -1,15 +1,16 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.ChaCha
     (
     -- * ChaCha types

--- a/PC/Crypto/Prim/Class.hs
+++ b/PC/Crypto/Prim/Class.hs
@@ -1,21 +1,22 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 -- |
 -- Module      : PC.Crypto.Prim.Class
--- Copyright   : (c) 2013-2014 PivotCloud, Inc
--- License     : All Right Reserved
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
 -- Maintainer  : support@pivotmail.com
 --
 -- Framework for cryptographic operations
---
+
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.Class
     (
     -- * Types

--- a/PC/Crypto/Prim/Curve25519.hs
+++ b/PC/Crypto/Prim/Curve25519.hs
@@ -1,15 +1,16 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+
 module PC.Crypto.Prim.Curve25519
     ( Curve25519SecretKey
     , Curve25519PublicKey

--- a/PC/Crypto/Prim/Ecc.hs
+++ b/PC/Crypto/Prim/Ecc.hs
@@ -1,11 +1,10 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
 
 module PC.Crypto.Prim.Ecc
     ( module PC.Crypto.Prim.Ecc.Key

--- a/PC/Crypto/Prim/Ecc/Key.hs
+++ b/PC/Crypto/Prim/Ecc/Key.hs
@@ -1,11 +1,11 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
@@ -16,6 +16,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DataKinds #-}
+
 module PC.Crypto.Prim.Ecc.Key
 ( PublicKey(..)
 , SecretKey(..)

--- a/PC/Crypto/Prim/Ecc/OpenSSL.hs
+++ b/PC/Crypto/Prim/Ecc/OpenSSL.hs
@@ -1,13 +1,14 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DataKinds #-}
+
 module PC.Crypto.Prim.Ecc.OpenSSL
 (
 -- * Elliptic Curve Mathematics

--- a/PC/Crypto/Prim/Ecc/OpenSSLBind.hs
+++ b/PC/Crypto/Prim/Ecc/OpenSSLBind.hs
@@ -1,14 +1,15 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+
 module PC.Crypto.Prim.Ecc.OpenSSLBind
     ( Point
     , Group

--- a/PC/Crypto/Prim/Ecc/Ops.hs
+++ b/PC/Crypto/Prim/Ecc/Ops.hs
@@ -1,12 +1,13 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE CPP #-}
+
 module PC.Crypto.Prim.Ecc.Ops
 #if defined(ECC_NATIVE)
 ( module PC.Crypto.Prim.Ecc.Native ) where import PC.Crypto.Prim.Ecc.Native

--- a/PC/Crypto/Prim/Ecdsa.hs
+++ b/PC/Crypto/Prim/Ecdsa.hs
@@ -1,11 +1,11 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -13,6 +13,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 module PC.Crypto.Prim.Ecdsa
 ( EcdsaSignature(..)
 , sign

--- a/PC/Crypto/Prim/Ed25519.hs
+++ b/PC/Crypto/Prim/Ed25519.hs
@@ -1,13 +1,14 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.Ed25519
     ( Ed25519SecretKey
     , Ed25519PublicKey

--- a/PC/Crypto/Prim/Hmac.hs
+++ b/PC/Crypto/Prim/Hmac.hs
@@ -1,12 +1,13 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE CPP #-}
+
 module PC.Crypto.Prim.Hmac
 #if defined(NATIVE)
 ( module PC.Crypto.Prim.Hmac.Native ) where import PC.Crypto.Prim.Hmac.Native

--- a/PC/Crypto/Prim/Hmac/Native.hs
+++ b/PC/Crypto/Prim/Hmac/Native.hs
@@ -1,11 +1,10 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
 
 module PC.Crypto.Prim.Hmac.Native
 ( hmacSha512

--- a/PC/Crypto/Prim/Imports.hs
+++ b/PC/Crypto/Prim/Imports.hs
@@ -1,3 +1,11 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
 module PC.Crypto.Prim.Imports
     (
     -- * Types

--- a/PC/Crypto/Prim/P256.hs
+++ b/PC/Crypto/Prim/P256.hs
@@ -1,23 +1,24 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 -- |
 -- Module      : PC.Crypto.Prim.P256
--- Copyright   : (c) 2013-2014 PivotCloud, Inc
--- License     : All Right Reserved
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
 -- Maintainer  : support@pivotmail.com
 --
 -- P256 support
---
+
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.P256
     ( 
     -- NIST P256 instance

--- a/PC/Crypto/Prim/P521.hs
+++ b/PC/Crypto/Prim/P521.hs
@@ -1,23 +1,24 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 -- |
 -- Module      : PC.Crypto.Prim.P521
--- Copyright   : (c) 2013-2014 PivotCloud, Inc
--- License     : All Right Reserved
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
 -- Maintainer  : support@pivotmail.com
 --
 -- P521 support
---
+
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.P521
     ( 
     -- NIST P521 instance

--- a/PC/Crypto/Prim/Pbkdf2.hs
+++ b/PC/Crypto/Prim/Pbkdf2.hs
@@ -1,11 +1,10 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
 
 module PC.Crypto.Prim.Pbkdf2
     ( pbkdf2Sha512

--- a/PC/Crypto/Prim/Poly1305.hs
+++ b/PC/Crypto/Prim/Poly1305.hs
@@ -1,15 +1,16 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.Poly1305
     (
     -- * Poly1305 types

--- a/PC/Crypto/Prim/SafeEq.hs
+++ b/PC/Crypto/Prim/SafeEq.hs
@@ -1,21 +1,22 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 -- |
 -- Module      : PC.Crypto.Prim.SafeEq
--- Copyright   : (c) 2013-2014 PivotCloud, Inc
--- License     : All Right Reserved
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
 -- Maintainer  : support@pivotmail.com
 --
 -- another Eq class supposed to defined time constant equal operation
---
+
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module PC.Crypto.Prim.SafeEq (SafeEq(..)) where
 
 import PC.Bytes.ByteArray

--- a/PC/Crypto/Prim/Sha.hs
+++ b/PC/Crypto/Prim/Sha.hs
@@ -1,12 +1,13 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE CPP #-}
+
 module PC.Crypto.Prim.Sha
 #if defined(NATIVE)
 ( module PC.Crypto.Prim.Sha.Native, pSha512_256 ) where

--- a/PC/Crypto/Prim/Sha/Native.hs
+++ b/PC/Crypto/Prim/Sha/Native.hs
@@ -1,12 +1,13 @@
--- Copyright (c) 2013-2014 PivotCloud, Inc. All Rights Reserved.
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 --
 -- NOTICE: The dissemination, reproduction, or copying of this file and the
 -- information contained herein, in any medium, is strictly forbidden.
 --
 -- The intellectual property and technical concepts contained herein are
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
---
+
 {-# LANGUAGE DataKinds #-}
+
 module PC.Crypto.Prim.Sha.Native
 (
 -- * SHA512

--- a/ac-crypto-prim.cabal
+++ b/ac-crypto-prim.cabal
@@ -20,7 +20,7 @@ License:             AllRightsReserved
 License-file:        LICENSE
 Author:              PivotCloud
 Maintainer:          vhanquez@pivotmail.com
-Copyright:           Copyright (c) 2014 Pivotcloud
+Copyright:           Copyright (c) 2014-2015 Pivotcloud
 Category:            Cryptography
 Build-type:          Simple
 cabal-version: >=1.10


### PR DESCRIPTION
Modules in the `Crypto` namespace are omitted. 
Only Haskell sources are updated.
