### PR TITLE
add missing files to cabal file

### DIFF
--- a/ac-crypto-prim.cabal
+++ b/ac-crypto-prim.cabal
@@ -25,6 +25,11 @@ Category:            Cryptography
 Build-type:          Simple
 cabal-version: >=1.10
 
+Extra-source-files:
+    cbits/*.h,
+    cbits/include/*.h,
+    cbits/*.c
+
 source-repository head
     type: git
     location: git@github.com:alephcloud/hs-ac-crypto-prim.git


### PR DESCRIPTION
This is supposed to fix #10. I don't know if all c sources are needed. Someone with more insights into this package may check this and replace the wildcards by a concrete package list.
